### PR TITLE
Update build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,17 @@ language: go
 env: BUILD_NUMBER=$TRAVIS_BUILD_NUMBER
 matrix:
   include:
-  - go: 1.10.x
-    script:
-    - make vet
-    - make test
   - go: 1.11.x
     env: GO111MODULE=on
     script:
     - make vet
     - make test
-  - go: 1.11.x
+  - go: 1.12.x
+    env: GO111MODULE=on
+    script:
+    - make vet
+    - make test
+  - go: 1.12.x
     env:
     - GO111MODULE=off
     script:


### PR DESCRIPTION
- Remove go 1.10
- Test  and build artifacts with go 1.12