### PR TITLE
Use kubeconfig as config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
     - make test
     - OS=darwin make build
     - OS=windows make build
+
 deploy:
   provider: releases
   api_key:

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -134,41 +134,37 @@ func (d *dexterOIDC) createOauth2Config() error {
 			}
 =======
 
-
 	// try to load credentials from CurrentContext
-	clientCfg,err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+	clientCfg, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
 
-	if(err == nil){
+	if err == nil {
 
 		for i, context := range clientCfg.Contexts {
 
-			if(i == clientCfg.CurrentContext){
-				for a, authInfo := range clientCfg.AuthInfos{
-					if(a == context.AuthInfo){
-						if(authInfo.AuthProvider != nil && authInfo.AuthProvider.Name == "oidc" ){
+			if i == clientCfg.CurrentContext {
+				for a, authInfo := range clientCfg.AuthInfos {
+					if a == context.AuthInfo {
+						if authInfo.AuthProvider != nil && authInfo.AuthProvider.Name == "oidc" {
 
 							d.clientSecret = authInfo.AuthProvider.Config["client-secret"]
 							d.clientID = authInfo.AuthProvider.Config["client-id"]
 
-							idp := authInfo.AuthProvider.Config["idp-issuer-url"];
+							idp := authInfo.AuthProvider.Config["idp-issuer-url"]
 
-							if(strings.Contains(idp,"google")){
+							if strings.Contains(idp, "google") {
 								oidcData.endpoint = "google"
 
-							} else if (strings.Contains(idp,"microsoft")){
+							} else if strings.Contains(idp, "microsoft") {
 								oidcData.endpoint = "azure"
 							}
 
-
 						}
-
-
 
 					}
 
 				}
 
-				continue;
+				continue
 			}
 
 >>>>>>> renew login based on current context

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -86,6 +86,7 @@ func (d *dexterOIDC) initialize() error {
 
 // setup and populate the OAuth2 config
 func (d *dexterOIDC) createOauth2Config() error {
+<<<<<<< HEAD
 	if d.clientID == "REDACTED" && d.clientSecret == "REDACTED" && defaultClientID == "" && defaultClientSecret == "" {
 		// try to load credentials from CurrentContext
 		clientCfg, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
@@ -131,6 +132,46 @@ func (d *dexterOIDC) createOauth2Config() error {
 				}
 
 			}
+=======
+
+
+	// try to load credentials from CurrentContext
+	clientCfg,err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+
+	if(err == nil){
+
+		for i, context := range clientCfg.Contexts {
+
+			if(i == clientCfg.CurrentContext){
+				for a, authInfo := range clientCfg.AuthInfos{
+					if(a == context.AuthInfo){
+						if(authInfo.AuthProvider != nil && authInfo.AuthProvider.Name == "oidc" ){
+
+							d.clientSecret = authInfo.AuthProvider.Config["client-secret"]
+							d.clientID = authInfo.AuthProvider.Config["client-id"]
+
+							idp := authInfo.AuthProvider.Config["idp-issuer-url"];
+
+							if(strings.Contains(idp,"google")){
+								oidcData.endpoint = "google"
+
+							} else if (strings.Contains(idp,"microsoft")){
+								oidcData.endpoint = "azure"
+							}
+
+
+						}
+
+
+
+					}
+
+				}
+
+				continue;
+			}
+
+>>>>>>> renew login based on current context
 		}
 	}
 

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -86,41 +86,37 @@ func (d *dexterOIDC) initialize() error {
 // setup and populate the OAuth2 config
 func (d *dexterOIDC) createOauth2Config() error {
 
-
 	// try to load credentials from CurrentContext
-	clientCfg,err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+	clientCfg, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
 
-	if(err == nil){
+	if err == nil {
 
 		for i, context := range clientCfg.Contexts {
 
-			if(i == clientCfg.CurrentContext){
-				for a, authInfo := range clientCfg.AuthInfos{
-					if(a == context.AuthInfo){
-						if(authInfo.AuthProvider != nil && authInfo.AuthProvider.Name == "oidc" ){
+			if i == clientCfg.CurrentContext {
+				for a, authInfo := range clientCfg.AuthInfos {
+					if a == context.AuthInfo {
+						if authInfo.AuthProvider != nil && authInfo.AuthProvider.Name == "oidc" {
 
 							d.clientSecret = authInfo.AuthProvider.Config["client-secret"]
 							d.clientID = authInfo.AuthProvider.Config["client-id"]
 
-							idp := authInfo.AuthProvider.Config["idp-issuer-url"];
+							idp := authInfo.AuthProvider.Config["idp-issuer-url"]
 
-							if(strings.Contains(idp,"google")){
+							if strings.Contains(idp, "google") {
 								oidcData.endpoint = "google"
 
-							} else if (strings.Contains(idp,"microsoft")){
+							} else if strings.Contains(idp, "microsoft") {
 								oidcData.endpoint = "azure"
 							}
 
-
 						}
-
-
 
 					}
 
 				}
 
-				continue;
+				continue
 			}
 
 		}

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -161,6 +161,7 @@ func (d *dexterOIDC) createOauth2Config() error {
 	default:
 		return errors.New(fmt.Sprintf("unsupported endpoint: %s", oidcData.endpoint))
 	}
+
 	return nil
 }
 

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -86,7 +86,6 @@ func (d *dexterOIDC) initialize() error {
 
 // setup and populate the OAuth2 config
 func (d *dexterOIDC) createOauth2Config() error {
-<<<<<<< HEAD
 	if d.clientID == "REDACTED" && d.clientSecret == "REDACTED" && defaultClientID == "" && defaultClientSecret == "" {
 		// try to load credentials from CurrentContext
 		clientCfg, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
@@ -132,42 +131,6 @@ func (d *dexterOIDC) createOauth2Config() error {
 				}
 
 			}
-=======
-
-	// try to load credentials from CurrentContext
-	clientCfg, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
-
-	if err == nil {
-
-		for i, context := range clientCfg.Contexts {
-
-			if i == clientCfg.CurrentContext {
-				for a, authInfo := range clientCfg.AuthInfos {
-					if a == context.AuthInfo {
-						if authInfo.AuthProvider != nil && authInfo.AuthProvider.Name == "oidc" {
-
-							d.clientSecret = authInfo.AuthProvider.Config["client-secret"]
-							d.clientID = authInfo.AuthProvider.Config["client-id"]
-
-							idp := authInfo.AuthProvider.Config["idp-issuer-url"]
-
-							if strings.Contains(idp, "google") {
-								oidcData.endpoint = "google"
-
-							} else if strings.Contains(idp, "microsoft") {
-								oidcData.endpoint = "azure"
-							}
-
-						}
-
-					}
-
-				}
-
-				continue
-			}
-
->>>>>>> renew login based on current context
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gini/dexter
 require (
 	cloud.google.com/go v0.37.1 // indirect
 	github.com/coreos/go-oidc v2.0.0+incompatible
+	github.com/davecgh/go-spew v1.1.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
 	github.com/imdario/mergo v0.3.6 // indirect


### PR DESCRIPTION
This pull request makes dexter able to login based on configuration of current context. If oidc is configured for current context it fetches client-id, client-secret, idp-issuer-url and use it to login and get new token.