### PR TITLE
added -k / --kube-config flag in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Flags:
   -i, --client-id string       Google clientID (default "REDACTED")
   -s, --client-secret string   Google clientSecret (default "REDACTED")
   -d, --dry-run                Toggle config overwrite
+  -k, --kube-config            Define the Kubeconfig to edit
   -h, --help                   help for auth
 
 Global Flags:


### PR DESCRIPTION
**TLDR**  
Existing Flag missing in README

--- 
I was searching for exactly this option and found it in the code. 
Tried it out and worked! 

So why not tell anybody to use this flag?

