### PR TITLE
Support build time provider specification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,8 @@ bin/$(ARCH)/$(BIN):
 	    -X $(PKG)/version.GITHASH=$(GIT_HASH) \
 	    -X $(PKG)/version.DOB=$(DOB) \
 	    -X $(PKG)/cmd.buildTimeClientID=$(CLIENT_ID) \
-	    -X $(PKG)/cmd.buildTimeClientSecret=$(CLIENT_SECRET)"
+	    -X $(PKG)/cmd.buildTimeClientSecret=$(CLIENT_SECRET) \
+	    -X $(PKG)/cmd.buildTimeProvider=$(DEFAULT_PROVIDER)"
 
 # Run go vet on repo
 vet:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ It is possible to embed your Google credentials into the resulting binary.
 CLIENT_ID=abc123.apps.googleusercontent.com CLIENT_SECRET=mySecret OS=linux make
 ```
 
+You can streamline your user experience even more by also specifying a
+default provider. `dexter auth` will then run the specified provider.
+Valid choices are `google` and `azure`.
+
+```
+DEFAULT_PROVIDER=google make
+```
+
 ## Run dexter
 
 Run `dexter` without a command to access the help screen/intro.


### PR DESCRIPTION
You can set a default provider at compile time. If the variable is set `dexter auth` will start the flow and users don't need to explicitly specify the provider anymore. 

Closes #29 