### PR TITLE
Add a command line parameter to communicate back the email that user used for logging in

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -409,7 +409,7 @@ func init() {
 	AuthCmd.PersistentFlags().StringVarP(&kubeConfig, "kube-config", "k", kubeConfigDefaultPath, "Overwrite the default location of kube config")
 	AuthCmd.PersistentFlags().StringVarP(&kubeUsername, "kube-username", "u", "", "Username identifier in the kube config")
 	AuthCmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "d", false, "Toggle config overwrite")
-        AuthCmd.PersistentFlags().StringVarP(&emailFile, "write-email", "f", "", "Write user email to the specified file for use with other tooling")
+	AuthCmd.PersistentFlags().StringVarP(&emailFile, "write-email", "f", "", "Write user email to the specified file for use with other tooling")
 }
 
 // initiate the OIDC flow. This func should be called in each cobra command

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -41,6 +41,7 @@ var (
 	kubeConfig   string
 	kubeUsername string
 	dryRun       bool
+	emailFile    string
 
 	// Cobra command
 	AuthCmd = &cobra.Command{
@@ -306,6 +307,14 @@ func (d *DexterOIDC) writeK8sConfig(token *oauth2.Token) error {
 
 	userIdentifier := customClaim.Email
 
+        if emailFile != "" {
+		log.Info(fmt.Sprintf("writing email to %s", emailFile))
+		err := ioutil.WriteFile(emailFile, []byte(userIdentifier+"\n"), 0644)
+		if err != nil {
+			return errors.New(fmt.Sprintf("Error writing email to file: %s", err))
+		}
+	}
+
 	if d.kubeUsername != "" {
 		userIdentifier = d.kubeUsername
 	}
@@ -400,6 +409,7 @@ func init() {
 	AuthCmd.PersistentFlags().StringVarP(&kubeConfig, "kube-config", "k", kubeConfigDefaultPath, "Overwrite the default location of kube config")
 	AuthCmd.PersistentFlags().StringVarP(&kubeUsername, "kube-username", "u", "", "Username identifier in the kube config")
 	AuthCmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "d", false, "Toggle config overwrite")
+        AuthCmd.PersistentFlags().StringVarP(&emailFile, "write-email", "f", "", "Write user email to the specified file for use with other tooling")
 }
 
 // initiate the OIDC flow. This func should be called in each cobra command

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -307,7 +307,7 @@ func (d *DexterOIDC) writeK8sConfig(token *oauth2.Token) error {
 
 	userIdentifier := customClaim.Email
 
-        if emailFile != "" {
+	if emailFile != "" {
 		log.Info(fmt.Sprintf("writing email to %s", emailFile))
 		err := ioutil.WriteFile(emailFile, []byte(userIdentifier+"\n"), 0644)
 		if err != nil {

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -308,7 +308,7 @@ func (d *DexterOIDC) writeK8sConfig(token *oauth2.Token) error {
 	userIdentifier := customClaim.Email
 
 	if emailFile != "" {
-		log.Info(fmt.Sprintf("writing email to %s", emailFile))
+		log.Infof("Writing user email to %s", emailFile)
 		err := ioutil.WriteFile(emailFile, []byte(userIdentifier+"\n"), 0644)
 		if err != nil {
 			return errors.New(fmt.Sprintf("Error writing email to file: %s", err))

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.7 // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.7 // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect


### PR DESCRIPTION
For integration of other internal tooling it is necessary to know _which_ account was just added to `kubeconfig` by `dexter`. Then other tooling may use this information to create, for example, a new context with that user in `kubeconfig`. Without this it is not possible to guess which of the accounts in `kubeconfig` was just updated.

This PR adds a new command line parameter `-f` that allows specifying a file name where dexter would write the email/identity/user just authenticated.