### PR TITLE
fix&bring the CI update to date, document the release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,23 +6,31 @@ on:
   pull_request:
     branches: [ master ]
 
-jobs:
+permissions:
+  contents: write
 
-  build:
+jobs:
+  goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Go
-        uses: actions/setup-go@v2
+      -
+        name: Checkout
+        uses: actions/checkout@v4
         with:
-          go-version: 1.23
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.2
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
-          args: build --skip-validate --rm-dist --snapshot
+          version: 'latest'
+          # --snapshot's goal is to ignore the existing tagging.
+          # We are just veryfying this builds, we don't intend to release in this step.
+          args: build --clean --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
           version: 'latest'
           # --snapshot's goal is to ignore the existing tagging.
           # We are just veryfying this builds, we don't intend to release in this step.
-          args: build --clean --snapshot
+          # validate refers to git tags - we don't need to check semver at this stage yet.
+          args: build --clean --snapshot --skip validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.23
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.23.2
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,7 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
-    branches:
-      - master
+      - '[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,27 +3,34 @@ name: Release
 on:
   push:
     tags:
-      - '*'
+      - '[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - master
+
+permissions:
+  contents: write
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      -
+        name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@v2
+      -
+        name: Set up Go
+        uses: actions/setup-go@v5
         with:
           go-version: 1.23.2
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
-          args: release --rm-dist
+          version: 'latest'
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,5 @@
-# This is an example .goreleaser.yml file with some sensible defaults.
-# Make sure to check the documentation at https://goreleaser.com
+version: 2
+
 before:
   hooks:
     # You may remove this if you don't use go modules.
@@ -41,7 +41,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+## release workflow
+
+We use a combination of [GitHub Actions](https://docs.github.com/en/actions) and [goreleaser](https://goreleaser.com/)
+
+Configurations for those shouldn't generally require adjusting, but if they do, they are found underneath `.github` and `.goreleaser.yml`
+
+In order to release:
+
+1) Merge your changes to master
+2) Push a tag following semVer. If you are unsure of what version to assign, you can find the concepts described here: https://semver.org/
+3) Verify the github action defined in .github/ completed and a new release is available. You can see the status in the github web UI.
+


### PR DESCRIPTION
This fixes and updates deprecated parts of the release workflow and bumps the Go version to a non-deprecated one. (1.23.2)

It corrects broken .goreleaser.yaml and addresses all current deprecation warnings in it. 
`depandabot` changes are intentionally kept out the scope of this - I will have depandabot rebase off of this branch and we can go from there.

Also does minor corrections to when the release step runs - now it's only on correct semver tags and only if those exist on `master`

I tested this by adjusting the branch restriction to point at this branch, pushing a tag and seeing it creates a release succesfully.

I then deleted it to not confuse any potential other users of goreleaser and dropped that test commit from my branch. 